### PR TITLE
CI: Build theme before deploying it

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,8 +42,7 @@ jobs:
 
     deploy:
         needs: build
-        # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -42,10 +42,32 @@ jobs:
 
     deploy:
         needs: build
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        # if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push'
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+            - name: Get Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo '::set-output name=dir::$(yarn cache dir)'
+            - name: Cache Yarn
+              uses: actions/cache@v1
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
+
+            - name: Setup Node
+              uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node-version }}
+            - run: npm install yarn
+            - run: yarn install
+
+            - run: yarn zip
+
             - name: Deploy Ghost theme
               uses: TryGhost/action-deploy-theme@v1.2.0
               with:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -73,3 +73,4 @@ jobs:
               with:
                   api-url: ${{ secrets.GHOST_API_URL }}
                   api-key: ${{ secrets.GHOST_DEPLOY_THEME_ADMIN_API_KEY }}
+                  exclude: "dist/* node_modules/*"


### PR DESCRIPTION
Currently, the theme is not built before deployment onto Ghost (blame it on https://github.com/TryGhost/action-deploy-theme), so we need to fire up `yarn zip` to get the assets built before deployment.