### PR TITLE
Stories: Retrieve tags and authors in post block

### DIFF
--- a/page-stories.hbs
+++ b/page-stories.hbs
@@ -64,7 +64,7 @@
             </div>
         </div>
         <div class="gh-postfeed">
-        {{#get "posts"}}
+        {{#get "posts" include="tags,authors"}}
             {{#foreach posts}}
                 {{> "card"}} {{!-- partials/card.hbs --}}
             {{/foreach}}


### PR DESCRIPTION
This PR fixes a bug with the filter functionality on the Stories page, where tag classes were not included in `.post-card`s.