### PR TITLE
Gulp: Replace `uglify` with `terser`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,15 +2,15 @@ const { series, watch, src, dest, parallel } = require("gulp");
 const pump = require("pump");
 
 // gulp plugins and utils
-var livereload = require("gulp-livereload");
-var postcss = require("gulp-postcss");
-var zip = require("gulp-zip");
-var uglify = require("gulp-uglify");
-var beeper = require("beeper");
+const livereload = require("gulp-livereload");
+const postcss = require("gulp-postcss");
+const zip = require("gulp-zip");
+const uglify = require("gulp-uglify");
+const beeper = require("beeper");
 
 // postcss plugins
-var atImport = require("postcss-import");
-var tailwindcss = require("tailwindcss");
+const atImport = require("postcss-import");
+const tailwindcss = require("tailwindcss");
 
 function serve(done) {
     livereload.listen();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,7 +5,7 @@ const pump = require("pump");
 const livereload = require("gulp-livereload");
 const postcss = require("gulp-postcss");
 const zip = require("gulp-zip");
-const uglify = require("gulp-uglify");
+const terser = require("gulp-terser-js");
 const beeper = require("beeper");
 
 // postcss plugins
@@ -51,7 +51,9 @@ function js(done) {
     pump(
         [
             src("assets/js/*.js", { sourcemaps: true }),
-            uglify(),
+            terser({
+                mangle: { toplevel: true },
+            }),
             dest("assets/built/", { sourcemaps: "." }),
             livereload(),
         ],

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "gulp": "4.0.2",
         "gulp-livereload": "4.0.2",
         "gulp-postcss": "9.0.0",
+        "gulp-terser-js": "^5.2.2",
         "gulp-uglify": "3.0.2",
         "gulp-zip": "5.1.0",
         "postcss": "^8.2.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,7 +1149,7 @@ combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.18.0, commander@^2.19.0:
+commander@^2.18.0, commander@^2.19.0, commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -2412,6 +2412,17 @@ gulp-postcss@9.0.0:
     fancy-log "^1.3.3"
     plugin-error "^1.0.1"
     postcss-load-config "^2.1.1"
+    vinyl-sourcemaps-apply "^0.2.1"
+
+gulp-terser-js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/gulp-terser-js/-/gulp-terser-js-5.2.2.tgz#3d93db9b2b83f35dfcc5b209af6b1762756eb6a3"
+  integrity sha512-4ull0HzTWeWjRPiGmAFmdhRcEDOG+r7aXivNHOBQzElLzMaeVKQwmCPDi2juBzUUkjAkPkKb1jHVoJN/PKTvcA==
+  dependencies:
+    plugin-error "^1.0.1"
+    source-map "^0.7.3"
+    terser "^4.6.12"
+    through2 "^3.0.1"
     vinyl-sourcemaps-apply "^0.2.1"
 
 gulp-uglify@3.0.2:
@@ -4827,6 +4838,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@~0.5.12:
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz"
@@ -4837,10 +4856,15 @@ source-map@^0.5.1, source-map@^0.5.6:
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.1:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
+source-map@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.3.tgz#5302f8169031735226544092e64981f751750383"
+  integrity sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
 
 sparkles@^1.0.0:
   version "1.0.1"
@@ -5094,6 +5118,15 @@ tar-stream@^2.1.2:
     fs-constants "^1.0.0"
     inherits "^2.0.3"
     readable-stream "^3.1.1"
+
+terser@^4.6.12:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
+  integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.6.1"
+    source-map-support "~0.5.12"
 
 through2-filter@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR fixes https://github.com/AdvisorySG/ghost-advisory-theme/issues/190 using the `gulp-terser-js` plugin at https://github.com/gulp-community/gulp-terser-js.