### PR TITLE
Simplify local addition of content API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This method is not officially supported by Ghost and might break any time (thoug
 We have two features which make use of Ghost's content API:
 
 1. [SearchInGhostEasy](https://github.com/gmfmi/searchinghost-easy), which adds a client-side full-text search for articles.
-1. Population of event cards in the homepage
+2. Population of event cards in the homepage
 
 If you want these features to be functional on your local machine, you'll need to update [default.hbs](./default.hbs) with a new local content API key. To add a new key, go to Integrations > Custom Integrations > Add custom integration and copy the content API key.
 

--- a/README.md
+++ b/README.md
@@ -53,9 +53,14 @@ Finally, run `yarn dev` in the `content/themes/ghost-advisory-theme/` directory 
 
 This method is not officially supported by Ghost and might break any time (though the theme handling logic is unlikely to be modified in the foreseeable future). Take note that if you add new post templates, you may need to restart Ghost manually for the changes to take place in the Admin panel.
 
-# Search
+# Content API Key
 
-We use [SearchInGhostEasy](https://github.com/gmfmi/searchinghost-easy) to implement a client-side full-text search for articles. If you want search to be functional on your local machine, you'll need to update [default.hbs](./default.hbs) with a new local content API key. See the [SearchInGhostEasy documentation for more information](https://github.com/gmfmi/searchinghost-easy).
+We have two features which make use of Ghost's content API:
+
+1. [SearchInGhostEasy](https://github.com/gmfmi/searchinghost-easy), which adds a client-side full-text search for articles.
+1. Population of event cards in the homepage
+
+If you want these features to be functional on your local machine, you'll need to update [default.hbs](./default.hbs) with a new local content API key. To add a new key, go to Integrations > Custom Integrations > Add custom integration and copy the content API key.
 
 # Copyright & License
 

--- a/assets/js/eventCardFetcher.js
+++ b/assets/js/eventCardFetcher.js
@@ -1,7 +1,7 @@
 $(function () {
     var api = new GhostContentAPI({
-        url: "https://beta.advisory.sg",
-        key: "336313a0318904e945f0938d06",
+        url: ADVISORY.SITE_URL,
+        key: ADVISORY.CONTENT_API_KEY,
         version: "v4",
     });
 

--- a/default.hbs
+++ b/default.hbs
@@ -63,10 +63,18 @@
         <script src="https://cdn.jsdelivr.net/gh/gmfmi/searchinghost-easy@latest/dist/searchinghost-easy-backpack.js"></script>
 
         <script>
-            // contentApiKey is instance-dependent; replace this with a new key if
-            // testing on a local instance
-            new SearchinGhostEasy({ contentApiKey: '3ecdb68993794bc0157e776e5d' });
+            window.ADVISORY = {
+                SITE_URL: "{{@site.url}}",
+                // Note: CONTENT_API_KEY is instance-dependent; this is the key for `beta.advisory.sg`.
+                CONTENT_API_KEY: "3ecdb68993794bc0157e776e5d",
+            };
 
+            if (/^[a-z]+:\/\/localhost[:\/]/.test(ADVISORY.SITE_URL)) {
+                // Replace this with a new key if testing on a local instance.
+                ADVISORY.CONTENT_API_KEY = "";
+            }
+
+            new SearchinGhostEasy({ contentApiKey: ADVISORY.CONTENT_API_KEY });
 
             // Filter feature
             let primaryFilters = "";


### PR DESCRIPTION
Note: this commit causes both SearchInGhost and our custom event loading code to use the same content API key. I don't think there's much disadvantage to that, but we can always switch back to using separate keys if desired.