### PR TITLE
Tailwind: Enable JIT compiler

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ const handleError = (done) => (err) => done(err);
 
 function hbs(done) {
     pump(
-        [src(["*.hbs", "**/**/*.hbs", "!node_modules/**/*.hbs"]), livereload()],
+        [src(["*.hbs", "**/*.hbs", "!node_modules/**/*.hbs"]), livereload()],
         handleError(done)
     );
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+    mode: "jit",
     purge: ["*.hbs", "**/*.hbs", "!node_modules/**/*.hbs"],
     darkMode: false, // or 'media' or 'class'
     theme: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    purge: ["./*.hbs", "./**/*.hbs"],
+    purge: ["*.hbs", "**/*.hbs", "!node_modules/**/*.hbs"],
     darkMode: false, // or 'media' or 'class'
     theme: {
         extend: {},


### PR DESCRIPTION
This PR enables [the new JIT compiler](https://tailwindcss.com/docs/just-in-time-mode) for Tailwind, which is still in active development. The compiler appears to be close to reaching feature parity and can speed up development significantly. It provides [new features](https://tailwindcss.com/docs/just-in-time-mode#new-features) such as stackable variants and arbitrary value support.