### PR TITLE
Fixing Event Cards

### DIFF
--- a/home.hbs
+++ b/home.hbs
@@ -1,6 +1,6 @@
 {{!< default}}
 
-<div class="w-full max-w-screen-xl mx-auto my-0 prose lg:prose-xl max-w-none">
+<div class="w-full max-w-screen-xl mx-auto my-0 max-w-none">
     <h2 class="text-center m-4">
         Featured Stories
     </h2>
@@ -14,7 +14,7 @@
     <h2 class="text-center m-4">
         Upcoming Events
     </h2>
-    <div id="event-card-container">
+    <div id="event-card-container" class="m-4">
         <p id="event-card-placeholder" class="text-center m-10 text-xl lg:text-2xl">Loading...</p>
     </div>
 </div>


### PR DESCRIPTION
for https://github.com/AdvisorySG/ghost-advisory-theme/issues/283
Fixing the formatting of event cards by
1. Adding a margin to event-card-container (So that there is a margin at the bottom)
2. Removing the prose classes from home.hbs (since it adds unnecessary padding to the text in the card, and does not cause a change
 
![image](https://user-images.githubusercontent.com/18213722/129453073-253fe3a4-045f-4628-9e30-306922a4a752.png)
