### PR TITLE
Quick fix for big advisory logo issue

### DIFF
--- a/partials/footer.hbs
+++ b/partials/footer.hbs
@@ -1,7 +1,9 @@
 <footer class="bg-black text-white py-4">
-    <div class="w-4/5 block md:flex m-auto p">
-        <img class="flex flex-wrap m-auto md:w-1/6" src="https://advisorysg-ghost.s3.ap-southeast-1.amazonaws.com/2021/09/advisory-logo.webp"/>
-        <div class="flex flex-wrap md:w-3/6">
+    <div class="w-4/5 block md:flex m-auto">
+        <div class="flex flex-auto md:w-3/6">
+            <div class="w-1/2 pb-3 md:w-1/4">
+                <img src="https://advisorysg-ghost.s3.ap-southeast-1.amazonaws.com/2021/09/advisory-logo.webp"/>
+            </div>
             <div class="w-1/2 pb-3 md:w-1/4">
                 <strong class="py-2 block leading-normal">
                     Who We Are


### PR DESCRIPTION
Did a quick fix for the huge advisory logo issue

Original tailwind styling seems abit broken so I used the boilerplate code from the other blocks to fix the sizing issue.
Changed flex property of div to flex auto

This code change may not be what youre looking for tho depends on how you wanna style the mobile version